### PR TITLE
Update gradle plugin version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.0.0-alpha5'
+        classpath 'com.android.tools.build:gradle:2.1.0-alpha1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
Seems to fix https://github.com/iammert/MaterialIntroView/issues/25

It appears that the android library plugin fails to build properly on the previous version of gradle plugin the library uses.